### PR TITLE
Added help text color for Checkbox dark mode

### DIFF
--- a/src/Components/Checkbox/Checkbox.tsx
+++ b/src/Components/Checkbox/Checkbox.tsx
@@ -55,7 +55,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
           {label}
         </label>
 
-        {help && <div className="text-gray-500">{help}</div>}
+        {help && <div className="text-gray-500 dark:text-gray-400">{help}</div>}
       </div>
     </div>
   );


### PR DESCRIPTION
When dark mode is enable Checkbox component help text color is less visible
I have added help text color for better visibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the help text color in the Checkbox component for better visibility in dark theme mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->