### PR TITLE
feat: TextField ref forwarding & Checkbox ReactNode label

### DIFF
--- a/src/Components/Checkbox/Checkbox.tsx
+++ b/src/Components/Checkbox/Checkbox.tsx
@@ -3,7 +3,7 @@ import { twMerge } from 'tailwind-merge';
 import { getColorClass } from '../../utils/colorUtils';
 
 interface CheckboxProps {
-  label: string;
+  label: React.ReactNode;
   checked?: boolean;
   className?: string;
   labelClassName?: string;
@@ -12,7 +12,7 @@ interface CheckboxProps {
   onChange?: (checked: boolean) => void;
 }
 
-const Checkbox: React.FC<CheckboxProps> = ({
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(({
   label,
   help,
   className,
@@ -20,7 +20,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
   onChange,
   disabled = false,
   ...props
-}) => {
+}, ref) => {
   const id = `input-${Math.random().toString(36).substr(2, 9)}`;
 
   // Get color classes
@@ -32,6 +32,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
     <div className="relative flex gap-x-3 mb-4">
       <div className="flex h-6 items-center">
         <input
+          ref={ref}
           type="checkbox"
           checked={props.checked}
           id={id}
@@ -65,6 +66,8 @@ const Checkbox: React.FC<CheckboxProps> = ({
       </div>
     </div>
   );
-};
+});
+
+Checkbox.displayName = 'Checkbox';
 
 export { Checkbox };

--- a/src/Components/TextField/TextField.tsx
+++ b/src/Components/TextField/TextField.tsx
@@ -28,7 +28,7 @@ interface TextFieldProps extends Omit<React.InputHTMLAttributes<HTMLInputElement
   onChange: (value: string) => void;
 }
 
-const TextField: React.FC<TextFieldProps> = ({
+const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(({
   label,
   value,
   disabled = false,
@@ -52,7 +52,7 @@ const TextField: React.FC<TextFieldProps> = ({
   trailingAddon,
   onChange,
   ...rest
-}) => {
+}, ref) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onChange(event.target.value);
   };
@@ -93,6 +93,7 @@ const TextField: React.FC<TextFieldProps> = ({
         {addon && <Fragment>{addon}</Fragment>}
 
         <input
+          ref={ref}
           id={id}
           type={type}
           value={value}
@@ -122,6 +123,8 @@ const TextField: React.FC<TextFieldProps> = ({
       {error && <p className="text-red-600 dark:text-red-500 text-sm mt-2">{error}</p>}
     </div>
   );
-};
+});
+
+TextField.displayName = 'TextField';
 
 export { TextField };


### PR DESCRIPTION
## Summary
- **TextField**: Wrap component with `React.forwardRef` so consumers can pass `ref` to programmatically focus the underlying `<input>` element
- **Checkbox**: Widen `label` prop type from `string` to `React.ReactNode` to support rich content (e.g. links in terms & conditions labels)

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] TextField: verify `ref` prop correctly focuses the input
- [ ] Checkbox: verify JSX content (e.g. `<a>` tags) renders correctly in the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Checkbox component labels now support richer content, including formatted text and interactive elements in addition to plain text
* TextField component now enables ref forwarding, giving parent components direct access to the underlying input element for advanced integration scenarios
* Improved React DevTools compatibility with enhanced component display names for better debugging visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->