### PR TITLE
feat: add initialFocus support to Modal

### DIFF
--- a/src/Components/Modal/Modal.tsx
+++ b/src/Components/Modal/Modal.tsx
@@ -1,15 +1,16 @@
 import { Dialog, Transition } from '@headlessui/react';
 import classNames from 'classnames';
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, Ref, forwardRef } from 'react';
 import ReactDOM from 'react-dom';
 
 export interface ModalProps {
   isOpen: boolean;
   onClose(): void;
   maxWidth?: string;
+  initialFocus?: React.RefObject<HTMLElement>;
 }
 
-const Modal = ({ isOpen, onClose, maxWidth = 'lg', children }: PropsWithChildren<ModalProps>) => {
+const Modal = ({ isOpen, onClose, maxWidth = 'lg', initialFocus, children }: PropsWithChildren<ModalProps>) => {
   const maxWidthClass = {
     sm: 'sm:max-w-sm',
     md: 'sm:max-w-md',
@@ -30,6 +31,7 @@ const Modal = ({ isOpen, onClose, maxWidth = 'lg', children }: PropsWithChildren
         className="fixed z-10 inset-0 overflow-y-auto"
         open={isOpen}
         onClose={onClose}
+        initialFocus={initialFocus}
       >
         <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
           <Transition.Child
@@ -73,9 +75,10 @@ const Modal = ({ isOpen, onClose, maxWidth = 'lg', children }: PropsWithChildren
   );
 };
 
-const ModalHeader = ({ children, className }: PropsWithChildren<{ className?: string }>) => {
+const ModalHeader = forwardRef(({ children, className }: PropsWithChildren<{ className?: string }>, ref: Ref<HTMLDivElement>) => {
   return (
     <div
+      ref={ref}
       className={classNames(
         'text-lg font-medium text-gray-900 dark:text-gray-300 mb-4 px-5 pt-5',
         className
@@ -84,18 +87,18 @@ const ModalHeader = ({ children, className }: PropsWithChildren<{ className?: st
       {children}
     </div>
   );
-};
+});
 
-const ModalBody = ({ children, className }: PropsWithChildren<{ className?: string }>) => {
-  return <div className={classNames('px-5 pt-0', className)}>{children}</div>;
-};
+const ModalBody = forwardRef(({ children, className }: PropsWithChildren<{ className?: string }>, ref: Ref<HTMLDivElement>) => {
+  return <div ref={ref} className={classNames('px-5 pt-0', className)}>{children}</div>;
+});
 
-const ModalActions = ({ children, className }: PropsWithChildren<{ className?: string }>) => {
+const ModalActions = forwardRef(({ children, className }: PropsWithChildren<{ className?: string }>, ref: Ref<HTMLDivElement>) => {
   return (
-    <div className={classNames('px-5 py-4 mt-4 sm:px-6 sm:flex sm:flex-row-reverse', className)}>
+    <div ref={ref} className={classNames('px-5 py-4 mt-4 sm:px-6 sm:flex sm:flex-row-reverse', className)}>
       {children}
     </div>
   );
-};
+});
 
 export { Modal, ModalHeader, ModalBody, ModalActions };


### PR DESCRIPTION
## Summary
- Add `initialFocus` prop to Modal component, allowing users to control which element receives focus when the modal opens
- Convert `ModalHeader`, `ModalBody`, and `ModalActions` to use `forwardRef` so refs can be passed for use with `initialFocus`
- Clean replacement for PR #13 (which had yarn.lock merge conflicts after npm migration)

## Test plan
- [x] `npm run build` succeeds with no type errors
- [ ] Verify `initialFocus` prop correctly focuses the referenced element on modal open
- [ ] Verify existing Modal usage without `initialFocus` is unaffected