### PR TITLE
fix: add prepare script to build dist when installed from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "echo \"Error: no test specified\" && exit 0",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.16",


### PR DESCRIPTION
## Summary
- Adds a `"prepare": "npm run build"` script to `package.json` so that `dist/` is automatically built when the package is installed directly from git (e.g., `npm install weDevsOfficial/tail-react`).
- Without this, git-based installs fail because `dist/` is `.gitignore`d and the `main`, `module`, and `exports` fields all point to files inside `dist/`.

## Test plan
- [ ] Install the package from this branch via git (`npm install weDevsOfficial/tail-react#fix/add-prepare-script`) and verify `dist/` is built automatically
- [ ] Verify normal `npm install` from the registry still works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build automation process to ensure packages are built automatically during release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->