### PR TITLE
fix: use vite build in prepare script to avoid devDependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "echo \"Error: no test specified\" && exit 0",
-    "prepare": "npm run build"
+    "prepare": "vite build"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.16",


### PR DESCRIPTION
## Summary
- Changes the `prepare` script from `npm run build` (`tsc && vite build`) to `vite build` directly
- Fixes build failure when installing from git: `tsc` requires devDependencies (e.g. `minimatch` type definitions) which aren't installed for git dependencies
- `vite build` alone produces the `dist/` output that consuming projects need

## Test plan
- [ ] Install from this branch via git (`npm install weDevsOfficial/tail-react#fix/prepare-script-vite-build`) and verify `dist/` is built without errors
- [ ] Verify normal `npm install` from the registry still works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->