### PR TITLE
fix: externalize react/jsx-runtime to prevent bundling issues

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       fileName: 'index',
     },
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
       output: {
         globals: {
           react: 'React',


### PR DESCRIPTION
## Summary

- Adds `react/jsx-runtime` to the Rollup `external` list in `vite.config.ts`
- Prevents `react/jsx-runtime` from being bundled into the library output, which causes duplicate React instances and runtime errors when consumers install the package from git

## Context

When this package is installed directly from a git URL (e.g. `npm install github:user/tail-react`), the bundled `react/jsx-runtime` conflicts with the consumer's own React installation. Externalizing it ensures the consumer's React copy is used at runtime, consistent with how `react` and `react-dom` are already handled.

## Test plan

- [ ] Install the package from git in a consumer project and verify no duplicate React warnings
- [ ] Verify the built output no longer includes `react/jsx-runtime` source
- [ ] Confirm existing components render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to properly handle external runtime dependencies during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->