### PR TITLE
fix: dropdown stays open when clicking Inertia Link items

### DIFF
--- a/src/Components/Dropdown/DropdownItem.tsx
+++ b/src/Components/Dropdown/DropdownItem.tsx
@@ -15,11 +15,12 @@ const DropdownItem: React.FC<DropdownItemProps> = ({
 }) => {
   return (
     <Menu.Item>
-      {({ active }) => (
+      {({ focus, close }) => (
         <div
+          onClickCapture={close}
           className={cn(
             'hover:cursor-pointer',
-            active ? activeClass : '',
+            focus ? activeClass : '',
             className,
           )}
         >


### PR DESCRIPTION
## Problem:

When a `DropdownItem` wraps a child that calls `event.preventDefault()` on click
(e.g. an Inertia `<Link>`), Headless UI's merged click handler detects the flag and
bails out before invoking `close()`. This leaves the dropdown menu open after the
user clicks an item.

Additionally, the render-prop API used the deprecated `active` prop from Headless UI v1.

## Changes:

**`src/Components/Dropdown/DropdownItem.tsx`**

- Replaced `{ active }` with `{ focus, close }` in the `Menu.Item` render prop —
  `focus` is the Headless UI v2 replacement for the deprecated `active` prop.
- Updated the `className` condition from `active` → `focus`.
- Added `onClickCapture={close}` to the wrapper `<div>` — the capture phase fires
  before any child handler can call `preventDefault()`, guaranteeing the menu always
  closes on click regardless of child behaviour.

## Why `onClickCapture` instead of `onClick`:

React's `onClick` runs in the bubble phase. If a child calls `event.preventDefault()`
first, Headless UI's merged handler sees the flag and skips `close()`. `onClickCapture`
runs top-down (parent before child), so `close()` is called unconditionally before the
child even sees the event.

## Testing:

- Verified `npm run build` (`tsc` + Vite) exits 0 with no type errors.
- Manual test: dropdown closes correctly when item wraps a plain `<a>`, an Inertia
  `<Link>`, and a button with `event.preventDefault()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown item click behavior to ensure dropdowns close more reliably when items are selected.
  * Fixed dropdown item visual state handling to better reflect focus and interaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->